### PR TITLE
Fix false clustering of computed features

### DIFF
--- a/deepcluster/deepcluster.py
+++ b/deepcluster/deepcluster.py
@@ -153,8 +153,6 @@ class DeepCluster(BaseEstimator):
         return
 
     def fit(self, data: data.DataLoader, remove_tl: bool = False):
-        # TODO: Load Checkpoint implementation
-
         self.model.features = torch.nn.DataParallel(self.model.features)
         self.model.to(self.device)
 
@@ -228,10 +226,7 @@ class DeepCluster(BaseEstimator):
             # print(f'Clustering Loss: {clustering_loss}')
 
             if len(self.cluster_logs) > 0:
-                if self.clustering_method == 'faiss':
-                    nmi = normalized_mutual_info_score(train_data.dataset.targets, self.cluster_logs[-1])
-                elif self.clustering_method == 'sklearn':
-                    nmi = normalized_mutual_info_score(train_data.dataset.targets, self.cluster_logs[-1])
+                nmi = normalized_mutual_info_score(train_data.dataset.targets, self.cluster_logs[-1])
 
                 print(f'NMI score: {nmi}')
 

--- a/deepcluster/deepcluster.py
+++ b/deepcluster/deepcluster.py
@@ -11,6 +11,7 @@ from utils import kmeans
 import os
 from sklearn.metrics import normalized_mutual_info_score
 from tqdm import tqdm
+import collections
 
 import torch
 from sklearn.cluster import KMeans
@@ -233,6 +234,12 @@ class DeepCluster(BaseEstimator):
                 print(f'- epoch {epoch} and current epoch {epoch+1}: {nmi}')
             
             print(f'- True labels and computed features at epoch {epoch+1}: {normalized_mutual_info_score(data.dataset.targets, train_data.dataset.targets)}')
+            print('-'*50)
+            
+            print('Label occurences:')
+            print(f'- True labels: {dict(sorted(collections.Counter(data.dataset.targets).items()))}')
+            print(f'- Computed labels: {dict(sorted(collections.Counter(train_data.dataset.targets).items()))}')
+            
             print('-'*50)
             
             if self.clustering_method == 'faiss':

--- a/deepcluster/deepcluster.py
+++ b/deepcluster/deepcluster.py
@@ -232,7 +232,7 @@ class DeepCluster(BaseEstimator):
 
                 print(f'- epoch {epoch} and current epoch {epoch+1}: {nmi}')
             
-            print(f'- True labels and computed features at epoch {epoch+1}: {normalized_mutual_info_score(data.dataset.targets, train_data.targets)}')
+            print(f'- True labels and computed features at epoch {epoch+1}: {normalized_mutual_info_score(data.dataset.targets, train_data.dataset.targets)}')
             print('-'*50)
             
             if self.clustering_method == 'faiss':

--- a/deepcluster/deepcluster.py
+++ b/deepcluster/deepcluster.py
@@ -225,11 +225,16 @@ class DeepCluster(BaseEstimator):
             print(f'Classification Loss: {loss}')
             # print(f'Clustering Loss: {clustering_loss}')
 
+            print('-'*50)
+            print('Normalized Mutual Information Scores:')
             if len(self.cluster_logs) > 0:
                 nmi = normalized_mutual_info_score(train_data.dataset.targets, self.cluster_logs[-1])
 
-                print(f'NMI score: {nmi}')
-
+                print(f'- epoch {epoch} and current epoch {epoch+1}: {nmi}')
+            
+            print(f'- True labels and computed features at epoch {epoch+1}: {normalized_mutual_info_score(data.dataset.targets, train_data.targets)}')
+            print('-'*50)
+            
             if self.clustering_method == 'faiss':
                 self.cluster_logs.append(train_data.dataset.targets)
             elif self.clustering_method == 'sklearn':

--- a/deepcluster/deepcluster.py
+++ b/deepcluster/deepcluster.py
@@ -237,7 +237,8 @@ class DeepCluster(BaseEstimator):
             print('-'*50)
             
             print('Label occurences:')
-            print(f'- True labels: {dict(sorted(collections.Counter(data.dataset.targets).items()))}')
+            true_labels, count = torch.unique(data.dataset.targets, return_counts=True)
+            print(f'- True labels: {dict(zip(true_labels.tolist(), count.tolist()))}')
             print(f'- Computed labels: {dict(sorted(collections.Counter(train_data.dataset.targets).items()))}')
             
             print('-'*50)
@@ -347,6 +348,7 @@ class DeepCluster(BaseEstimator):
         -------
         np.ndarray: Predicted features.
         """
+        self.model.eval()
         for i, (input, _) in tqdm(enumerate(data), desc='Computing Features', total=len(data)):
             input = input.to(self.device)
 

--- a/deepcluster/models/AlexNet.py
+++ b/deepcluster/models/AlexNet.py
@@ -58,6 +58,7 @@ class AlexNet(nn.Module):
         self.top_layer = nn.Linear(4096, num_classes)
         
         # Define Sobel Filter
+        self.sobel = None
         if sobel:
             grayscale = nn.Conv2d(in_channels=3, out_channels=1, kernel_size=1, stride=1, padding=0)
             grayscale.weight.data.fill_(1.0 / 3.0)
@@ -69,7 +70,7 @@ class AlexNet(nn.Module):
             self.sobel = nn.Sequential(grayscale, filter)
             for parameter in self.sobel.parameters():
                 parameter.require_grad = False
-                
+
     def forward(self, X: torch.Tensor):
             if self.sobel:
                 X = self.sobel(X)

--- a/deepcluster/models/ResNet.py
+++ b/deepcluster/models/ResNet.py
@@ -69,7 +69,7 @@ class Bottleneck(nn.Module):
 
 
 class ResNet(nn.Module):
-    def __init__(self, block, n_blocks: iter, img_channels: int = 3, num_classes: int = 1000):
+    def __init__(self, block, n_blocks: iter, img_channels: int = 3, num_classes: int = 1000, sobel = False):
         super(ResNet, self).__init__()
         self.in_channels: int = 64
 
@@ -85,6 +85,18 @@ class ResNet(nn.Module):
 
         self.avgpool = nn.AdaptiveAvgPool2d(output_size=(1, 1))
         self.top_layer = nn.Linear(in_features=512, out_features=num_classes)
+        
+        if sobel:
+            grayscale = nn.Conv2d(in_channels=3, out_channels=1, kernel_size=1, stride=1, padding=0)
+            grayscale.weight.data.fill_(1.0 / 3.0)
+            grayscale.bias.data.zero_()
+            filter = nn.Conv2d(in_channels=1, out_channels=2, kernel_size=3, stride=1, padding=1)
+            filter.weight.data[0, 0].copy_(torch.FloatTensor([[1, 0, -1], [2, 0, -2], [1, 0, -1]]))
+            filter.weight.data[1, 0].copy_(torch.FloatTensor([[1, 2, 1], [0, 0, 0], [-1, -2, -1]]))
+            filter.bias.data.zero_()
+            self.sobel = nn.Sequential(grayscale, filter)
+            for parameter in self.sobel.parameters():
+                parameter.require_grad = False
 
     def _make_layer(self, block, out_channels: int, n_blocks: int, stride=1) -> nn.Module:
         layers = []
@@ -108,6 +120,8 @@ class ResNet(nn.Module):
         return nn.Sequential(*layers)
 
     def forward(self, x: Tensor) -> Tensor:
+        if self.sobel:
+            out = self.sobel(out)
         out = self.conv1(x)
         out = self.bn1(out)
         out = self.relu(out)
@@ -125,21 +139,21 @@ class ResNet(nn.Module):
         return out
 
 
-def resnet18():
-    return ResNet(BasicBlock, (2, 2, 2, 2))
+def resnet18(sobel=False):
+    return ResNet(BasicBlock, (2, 2, 2, 2, sobel))
 
 
-def resnet34():
-    return ResNet(BasicBlock, (3, 4, 6, 3))
+def resnet34(sobel=False):
+    return ResNet(BasicBlock, (3, 4, 6, 3, sobel))
 
 
-def resnet50():
-    return ResNet(Bottleneck, (3, 4, 6, 3))
+def resnet50(sobel=False):
+    return ResNet(Bottleneck, (3, 4, 6, 3, sobel))
 
 
-def resnet101():
-    return ResNet(Bottleneck, (3, 4, 23, 3))
+def resnet101(sobel=False):
+    return ResNet(Bottleneck, (3, 4, 23, 3, sobel))
 
 
-def resnet152():
-    return ResNet(Bottleneck, (3, 8, 36, 3))
+def resnet152(sobel=False):
+    return ResNet(Bottleneck, (3, 8, 36, 3, sobel))

--- a/deepcluster/models/ResNet.py
+++ b/deepcluster/models/ResNet.py
@@ -84,7 +84,7 @@ class ResNet(nn.Module):
         self.layer4 = self._make_layer(block, 512, n_blocks[3], 2)
 
         self.avgpool = nn.AdaptiveAvgPool2d(output_size=(1, 1))
-        self.linear = nn.Linear(in_features=512, out_features=num_classes)
+        self.top_layer = nn.Linear(in_features=512, out_features=num_classes)
 
     def _make_layer(self, block, out_channels: int, n_blocks: int, stride=1) -> nn.Module:
         layers = []
@@ -120,7 +120,7 @@ class ResNet(nn.Module):
 
         out = self.avgpool(out)
         out = out.view(out.size(0), -1)
-        out = self.linear(out)
+        out = self.top_layer(out)
 
         return out
 

--- a/deepcluster/models/VGG.py
+++ b/deepcluster/models/VGG.py
@@ -91,6 +91,7 @@ class VGG16(nn.Module):
         self.top_layer = nn.Linear(4096, num_classes)
         
         # Define Sobel Filter
+        self.sobel = None
         if sobel:
             grayscale = nn.Conv2d(in_channels=3, out_channels=1, kernel_size=1, stride=1, padding=0)
             grayscale.weight.data.fill_(1.0 / 3.0)

--- a/deepcluster/train_deep_cluster.py
+++ b/deepcluster/train_deep_cluster.py
@@ -9,23 +9,41 @@ import faiss
 import numpy as np
 from torch.utils.data.sampler import RandomSampler
 
-def train_validation_data(data_dir: str, batch_size: int, seed: int, valid_size: float=0.1, shuffle=True) -> tuple:
-    transform = Compose(
-            [
-                Resize(256),
-                CenterCrop(224),
-                ToTensor(),
-                Normalize(
-                    mean=[0.485, 0.456, 0.406],
-                    std=[0.229, 0.224, 0.225]
-                )
-            ]
-        )
+def train_validation_data(data_dir: str, batch_size: int, seed: int, dataset: str='CIFAR10', valid_size: float=0.1, shuffle=True) -> tuple:
     print("Loading Dataset...")
-    train_data = torchvision.datasets.CIFAR10(
-        root=data_dir, train=True,
-        download=True, transform=transform,
-    )
+    if dataset == 'CIFAR10':
+        transform = Compose(
+                [
+                    Resize(256),
+                    CenterCrop(224),
+                    ToTensor(),
+                    Normalize(
+                        mean=[0.485, 0.456, 0.406],
+                        std=[0.229, 0.224, 0.225]
+                    )
+                ]
+            )
+        
+        train_data = torchvision.datasets.CIFAR10(
+            root=data_dir, train=True,
+            download=True, transform=transform,
+        )
+    elif dataset == 'MNIST':
+        transform = Compose(
+                [
+                    Resize(256),
+                    CenterCrop(224),
+                    ToTensor(),
+                    Normalize(
+                        (0.1307,), (0.3081,)
+                    )
+                ]
+            )
+        
+        train_data = torchvision.datasets.MNIST(
+            root=data_dir, train=True,
+            download=True, transform=transform,
+        )
 
     print("Done Loading Dataset.")
     
@@ -53,7 +71,7 @@ def main():
         )
     )
     print("Done Loading Dataset.") """
-
+    dataset_name = 'MNIST'
     device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
     print("Train on device:", device)
     
@@ -80,10 +98,15 @@ def main():
     loss = torch.nn.CrossEntropyLoss()
 
     # Cluster Assign Transformation
-    normalize = Normalize(
-        mean=[0.4914, 0.4822, 0.4465],
-        std=[0.2023, 0.1994, 0.2010]
-    )
+    if dataset_name == 'CIFAR10':
+        normalize = Normalize(
+            mean=[0.4914, 0.4822, 0.4465],
+            std=[0.2023, 0.1994, 0.2010]
+        )
+    elif dataset_name == 'MNIST':
+        normalize = Normalize(
+            (0.1307,), (0.3081,)
+        )
 
     ca_tf = Compose(
         [
@@ -107,7 +130,7 @@ def main():
         pca_reduction=3,
         cluster_assign_tf=ca_tf,
         epochs=3,
-        dataset_name='CIFAR10',
+        dataset_name=dataset_name,
         clustering_method='sklearn'
     )
 

--- a/deepcluster/train_deep_cluster.py
+++ b/deepcluster/train_deep_cluster.py
@@ -75,7 +75,7 @@ def main():
     device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
     print("Train on device:", device)
     
-    model = AlexNet(input_dim=2, num_classes=10, sobel=True).to(device)
+    model = AlexNet(input_dim=1, num_classes=10, sobel=False).to(device)
     torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
 
     # Optimizer
@@ -136,7 +136,7 @@ def main():
 
     #loader = torch.utils.data.DataLoader(cifar10, batch_size=batch_size)
 
-    train_loader = train_validation_data(data_dir='./data', batch_size=batch_size, seed=1)
+    train_loader = train_validation_data(data_dir='./data', batch_size=batch_size, dataset='MNIST', seed=1)
     
     print("Starting Training...")
     DC_model.fit(train_loader)


### PR DESCRIPTION
This will fix the false clustering of the computed features.

The idea is to remove the top layer of the CNN and obtain the features by the remaining layers. These features are then clustered. The resulting labels are then merged with the original dataset.

Before the CNN is trained, the top layer is newly created and also optimized in the process.

Note: This was basically implemented, but only optional. It seems like that making it mandatory solves the clustering issue, where all previously labeled features are pushed mainly into one cluster.