### PR TITLE
In-Algorithm Benchmarking + Torchvision Dataset simplified

### DIFF
--- a/deepcluster/deepcluster.py
+++ b/deepcluster/deepcluster.py
@@ -155,7 +155,7 @@ class DeepCluster(BaseEstimator):
             if metrics_file:
                 self.metrics_file = metrics_file
             else:
-                self.metrics_file = f'{BASE_METRICS}{self.dataset_name}/{datetime.now().strftime('%Y-%m-%d')}_{self.model}.csv' # The File the metrics are stored at after each epoch
+                self.metrics_file = f'{BASE_METRICS}{self.dataset_name}/{datetime.now().strftime("%Y-%m-%d")}_{self.model}.csv' # The File the metrics are stored at after each epoch
             
 
 

--- a/deepcluster/deepcluster.py
+++ b/deepcluster/deepcluster.py
@@ -525,6 +525,8 @@ class DeepCluster(BaseEstimator):
             nmi_epoch = normalized_mutual_info_score(pseudo_labels, self.cluster_logs[-1])
             self.train_nmi.append(nmi_epoch)
             print(f'- epoch {epoch} and current epoch {epoch+1}: {nmi_epoch}')
+        else:
+            nmi_epoch = 0.
 
         nmi = normalized_mutual_info_score(dataset_labels, pseudo_labels)
         print(f'- True labels and computed features at epoch {epoch+1}: {nmi}')

--- a/deepcluster/deepcluster.py
+++ b/deepcluster/deepcluster.py
@@ -577,7 +577,7 @@ class DeepCluster(BaseEstimator):
             os.makedirs(f'{BASE_METRICS}{self.dataset_name}')
         
         # When the file doesn't exist, create it and add the header
-        if not os.path.exists({self.metrics_file}):
+        if not os.path.exists(self.metrics_file):
             if self.verbose: print(f'Creating metrics file at \'{self.metrics_file}\'.')
             with open(self.metrics_file, 'w', newline='') as file:
                 writer = csv.writer(file)

--- a/deepcluster/deepcluster.py
+++ b/deepcluster/deepcluster.py
@@ -8,6 +8,7 @@ from torch.utils import data
 from sklearn.base import BaseEstimator
 import numpy as np
 from utils import faiss_kmeans
+from utils.benchmarking import Meter
 from utils.pseudo_labeled_dataset import PseudoLabeledData
 import os
 from sklearn.metrics import normalized_mutual_info_score
@@ -15,6 +16,8 @@ from tqdm import tqdm
 import collections
 import faiss
 import time
+from datetime import datetime
+import csv
 
 
 import torch
@@ -25,7 +28,10 @@ from torch import Tensor
 
 # Base folder for checkpoints
 BASE_CPT = './checkpoints/'
-
+# Base folder for metrics
+BASE_METRICS = './metrics/'
+# Metrics Header
+METRICS_HEADER = ['epoch', 'loss_avg', 'accuracy', 'nmi_true_ped', 'nmi_epochs', 'epoch_time', 'train_time', 'features_time', 'cluster_time', 'pca_time']
 
 class DeepCluster(BaseEstimator):
     def __init__(
@@ -44,7 +50,9 @@ class DeepCluster(BaseEstimator):
                 pca_reduction: int = 256,  # PCA reduction value for the amount of features to be kept
                 clustering_method: str = 'faiss',
                 pca_method: str = 'faiss',
-                pca_whitening: bool = True
+                pca_whitening: bool = True,
+                metrics: bool=True,
+                metrics_file: str=None, # Path to metrics csv file, mainly when continuing a previous training after the process stopped 
                 ):
         """DeepCluster Implementation based on the paper 'Deep Clustering for Unsupervised Learning of Visual Features' by M. Caron, P. Bojanowski, A. Joulin and M. Douze (Facebook AI Research). 
 
@@ -124,6 +132,7 @@ class DeepCluster(BaseEstimator):
         self.train_accuracies = []
         self.train_nmi = []
         self.execution_time = []
+        self.metrics=metrics
 
         self.pca_whitening = pca_whitening
 
@@ -132,6 +141,22 @@ class DeepCluster(BaseEstimator):
             self.clustering = faiss_kmeans.FaissKMeans(self.k)
         elif self.clustering_method == 'sklearn':
             self.clustering = KMeans(n_clusters=self.k)
+        
+        # Init metrics
+        if self.metrics:
+            self.epoch_time = Meter()
+            self.train_time = Meter()
+            self.loss_overall_avg = Meter()
+            self.accuracy_overall_avg = Meter()
+            self.features_time = Meter()
+            self.cluster_time = Meter()
+            self.pca_time = Meter()
+            
+            if metrics_file:
+                self.metrics_file = metrics_file
+            else:
+                self.metrics_file = f'{BASE_METRICS}{self.dataset_name}/{datetime.now().strftime('%Y-%m-%d')}_{self.model}.csv' # The File the metrics are stored at after each epoch
+            
 
 
     def save_checkpoint(self, epoch: int):
@@ -195,7 +220,8 @@ class DeepCluster(BaseEstimator):
 
         cudnn.benchmark = True
         fd = int(self.model.top_layer.weight.size()[1])
-
+        if self.metrics:
+            end = time.time()
         for epoch in range(self.start_epoch, self.epochs):
             start_time = time.time()
             if self.verbose: print(f'{"=" * 25} Epoch {epoch + 1} {"=" * 25}')
@@ -239,17 +265,30 @@ class DeepCluster(BaseEstimator):
             self.model.top_layer.to(self.device)
 
             losses, accuracies = self.train(train_data)
+            if self.metrics:
+                self.loss_overall_avg.update(losses)
+                self.accuracy_overall_avg.update(accuracies)
 
+            # Epoch Metrics
+            if self.metrics:
+                self.epoch_time.update(time.time() - end)
+                end = time.time()
+                
             # Print the results of this epoch
             self.print_results(epoch, losses, accuracies, train_data.dataset.targets, data.dataset.targets)
 
             # Store psuedo-labels
             self.cluster_logs.append(train_data.dataset.targets)
 
+            self.execution_time.append(time.time() - start_time)
+            
+            # Print Metrics
+            if self.metrics:
+                self.print_metrics(epoch)
+                        
             if self.verbose: print('Creating new checkpoint..')
             self.save_checkpoint(epoch)
             if self.verbose: print('Finished storing checkpoint')
-            self.execution_time.append(time.time() - start_time)
 
     def predict(self, batch: Tensor):
         """
@@ -283,6 +322,8 @@ class DeepCluster(BaseEstimator):
 
         losses = torch.zeros(len(train_data), dtype=torch.float32, requires_grad=False)
         accuracies = torch.zeros(len(train_data), dtype=torch.float32, requires_grad=False)
+        if self.metrics:
+            end = time.time()
         for i, (input, target) in tqdm(enumerate(train_data), desc='Training', total=len(train_data)):
             # Recasting target as LongTensor
             target = target.type(torch.LongTensor)
@@ -315,10 +356,15 @@ class DeepCluster(BaseEstimator):
             loss.backward()
             self.optimizer.step()
             self.optimizer_tl.step()
-
+            
             # Free up GPU memory
             del input, target, output, loss
             torch.cuda.empty_cache()
+            
+            # Train Metrics
+            if self.metrics:
+                self.train_time.update(time.time() - end)
+                end = time.time()
 
         return losses, accuracies
 
@@ -335,6 +381,8 @@ class DeepCluster(BaseEstimator):
         np.ndarray: Predicted features.
         """
         self.model.eval()
+        if self.metrics:
+            end = time.time()
         for i, (input, _) in tqdm(enumerate(data), desc='Computing Features', total=len(data)):
             input = input.to(self.device)
 
@@ -354,6 +402,10 @@ class DeepCluster(BaseEstimator):
             # Free up GPU memory
             del input, aux
             torch.cuda.empty_cache()
+            
+            if self.metrics:
+                self.features_time.update(time.time() - end)
+                end = time.time()
 
         return features
 
@@ -371,6 +423,9 @@ class DeepCluster(BaseEstimator):
         np.ndarray
             PCA reduced features with the remaining self.pca feature components.
         """
+        if self.metrics:
+            end = time.time()
+            
         if self.pca_method == 'faiss':
             _, dim = features.shape
             features = features.astype(np.float32)
@@ -392,6 +447,9 @@ class DeepCluster(BaseEstimator):
         rows = np.linalg.norm(features, axis=1)
         features = np.divide(features, rows.reshape((rows.shape[0], 1)))
 
+        if self.metrics:
+            self.pca_time.update(time.time() - end)
+        
         return features
 
     def apply_clustering(self, features: np.ndarray) -> np.ndarray:
@@ -407,10 +465,16 @@ class DeepCluster(BaseEstimator):
         np.ndarray
             Labels of the clustering result.
         """
+        if self.metrics:
+            end = time.time()
+            
         if self.clustering_method == 'faiss':
             labels = self.clustering.fit(features)
         elif self.clustering_method == 'sklearn':
             labels = self.clustering.fit_predict(features)
+
+        if self.metrics:
+            self.cluster_time.update(time.time() - end)
 
         return labels
 
@@ -458,11 +522,12 @@ class DeepCluster(BaseEstimator):
 
         print('Normalized Mutual Information Scores:')
         if len(self.cluster_logs) > 0:
-            nmi = normalized_mutual_info_score(pseudo_labels, self.cluster_logs[-1])
-            self.train_nmi.append(nmi)
-            print(f'- epoch {epoch} and current epoch {epoch+1}: {nmi}')
+            nmi_epoch = normalized_mutual_info_score(pseudo_labels, self.cluster_logs[-1])
+            self.train_nmi.append(nmi_epoch)
+            print(f'- epoch {epoch} and current epoch {epoch+1}: {nmi_epoch}')
 
-        print(f'- True labels and computed features at epoch {epoch+1}: {normalized_mutual_info_score(dataset_labels, pseudo_labels)}')
+        nmi = normalized_mutual_info_score(dataset_labels, pseudo_labels)
+        print(f'- True labels and computed features at epoch {epoch+1}: {nmi}')
         print('-'*50)
 
         print('Label occurences:')
@@ -474,3 +539,77 @@ class DeepCluster(BaseEstimator):
         print(f'- Computed labels: {dict(sorted(collections.Counter(pseudo_labels).items()))}')
 
         print('-'*50)
+        
+        if self.metrics:
+            self.write_metrics(epoch, nmi, nmi_epoch)
+            
+        return
+        
+    def write_metrics(self, epoch: int, nmi: float, nmi_epoch: float):
+        """Wrapper function to write metrics directly into a .csv file for data analytics.
+        This function will create a metrics folder in the main directory and in addition a sub-folder for the dataset, if either or both don't exist.
+        After, it creates, if not existing, a .csv file, add headers and appends the metrics after each epoch.
+        
+        The following metrics are stored, for each epoch:
+            - NMI between true and predicted labels
+            - NMI between previous and current epoch of the clustered feature labels
+            - Execution time for each epoch, training, feature calculation, clustering and PCA reduction
+            - Loss and Accuracy of the model training
+
+        Parameters
+        ----------
+        epoch: int,
+            Current epoch.
+            
+        nmi: float,
+            The Normalized Mutual Information Score between the true and predicted labels.
+        
+        nmi_epoch: float,
+            The Normalized Mutual Information Score between the current epoch clustered labels and of the previous epochs' clustered labels.
+        """
+        
+        if not os.path.exists(BASE_METRICS):
+            os.makedirs(BASE_METRICS)
+            
+        if not os.path.exists(f'{BASE_METRICS}{self.dataset_name}'):
+            os.makedirs(f'{BASE_METRICS}{self.dataset_name}')
+        
+        # When the file doesn't exist, create it and add the header
+        if not os.path.exists({self.metrics_file}):
+            if self.verbose: print(f'Creating metrics file at \'{self.metrics_file}\'.')
+            with open(self.metrics_file, 'w', newline='') as file:
+                writer = csv.writer(file)
+                writer.writerow(METRICS_HEADER)
+        
+            
+        if self.verbose:
+            print(f'Storing metrics of current epoch {epoch+1}...')
+            
+        with open(self.metrics_file, 'a', newline='') as file:
+            writer = csv.writer(file)
+            # Add Metrics Row
+            row = [
+                epoch, 
+                self.loss_overall_avg.val,
+                self.accuracy_overall_avg.val,
+                nmi,
+                nmi_epoch,
+                self.epoch_time.val,
+                self.train_time.val,
+                self.features_time.val,
+                self.cluster_time.val,
+                self.pca_time.val,
+            ]
+            writer.writerow(row)
+        
+        return
+    
+    def print_metrics(self, epoch: int):
+        
+        print('-' * 15, f' Metrics after {epoch+1} Epochs ', '-' * 15)
+        print(f'- Feature time: {self.features_time.val} [avg: {self.features_time.avg}]')
+        print(f'- PCA time: {self.pca_time.val} [avg: {self.pca_time.avg}]')
+        print(f'- Cluster time: {self.cluster_time.val} [avg: {self.cluster_time.avg}]')
+        print(f'- Training time: {self.train_time.val} [avg: {self.train_time.avg}]')
+        print(f'- Epoch time: {self.epoch_time.val} [avg: {self.epoch_time.avg}]')
+        print('-' * 60)

--- a/deepcluster/deepcluster.py
+++ b/deepcluster/deepcluster.py
@@ -266,8 +266,8 @@ class DeepCluster(BaseEstimator):
 
             losses, accuracies = self.train(train_data)
             if self.metrics:
-                self.loss_overall_avg.update(losses)
-                self.accuracy_overall_avg.update(accuracies)
+                self.loss_overall_avg.update(torch.mean(losses))
+                self.accuracy_overall_avg.update(torch.mean(accuracies))
 
             # Epoch Metrics
             if self.metrics:
@@ -285,6 +285,11 @@ class DeepCluster(BaseEstimator):
             # Print Metrics
             if self.metrics:
                 self.print_metrics(epoch)
+                self.features_time.reset()
+                self.pca_time.reset()
+                self.cluster_time.reset()
+                self.train_time.reset()
+                self.epoch_time.reset()
                         
             if self.verbose: print('Creating new checkpoint..')
             self.save_checkpoint(epoch)
@@ -592,15 +597,15 @@ class DeepCluster(BaseEstimator):
             # Add Metrics Row
             row = [
                 epoch, 
-                self.loss_overall_avg.val,
-                self.accuracy_overall_avg.val,
+                torch.mean(self.loss_overall_avg.val).numpy(),
+                torch.mean(self.accuracy_overall_avg.val).numpy(),
                 nmi,
                 nmi_epoch,
-                self.epoch_time.val,
-                self.train_time.val,
-                self.features_time.val,
-                self.cluster_time.val,
-                self.pca_time.val,
+                self.epoch_time.sum,
+                self.train_time.sum,
+                self.features_time.sum,
+                self.cluster_time.sum,
+                self.pca_time.sum,
             ]
             writer.writerow(row)
         
@@ -609,9 +614,9 @@ class DeepCluster(BaseEstimator):
     def print_metrics(self, epoch: int):
         
         print('-' * 15, f' Metrics after {epoch+1} Epochs ', '-' * 15)
-        print(f'- Feature time: {self.features_time.val} [avg: {self.features_time.avg}]')
-        print(f'- PCA time: {self.pca_time.val} [avg: {self.pca_time.avg}]')
-        print(f'- Cluster time: {self.cluster_time.val} [avg: {self.cluster_time.avg}]')
-        print(f'- Training time: {self.train_time.val} [avg: {self.train_time.avg}]')
-        print(f'- Epoch time: {self.epoch_time.val} [avg: {self.epoch_time.avg}]')
+        print(f'- Feature time: {self.features_time.sum} [avg: {self.features_time.avg}]')
+        print(f'- PCA time: {self.pca_time.sum} [avg: {self.pca_time.avg}]')
+        print(f'- Cluster time: {self.cluster_time.sum} [avg: {self.cluster_time.avg}]')
+        print(f'- Training time: {self.train_time.sum} [avg: {self.train_time.avg}]')
+        print(f'- Epoch time: {self.epoch_time.sum} [avg: {self.epoch_time.avg}]')
         print('-' * 60)

--- a/deepcluster/train_deep_cluster.py
+++ b/deepcluster/train_deep_cluster.py
@@ -1,6 +1,7 @@
 from models.AlexNet import AlexNet
 from deepcluster import DeepCluster
 from utils.faiss_kmeans import FaissKMeans
+from utils.datasets import dataset_loader
 
 import torch
 import torchvision
@@ -9,69 +10,9 @@ import faiss
 import numpy as np
 from torch.utils.data.sampler import RandomSampler
 
-def train_validation_data(data_dir: str, batch_size: int, seed: int, dataset: str='CIFAR10', valid_size: float=0.1, shuffle=True) -> tuple:
-    print("Loading Dataset...")
-    if dataset == 'CIFAR10':
-        transform = Compose(
-                [
-                    Resize(256),
-                    CenterCrop(224),
-                    ToTensor(),
-                    Normalize(
-                        mean=[0.485, 0.456, 0.406],
-                        std=[0.229, 0.224, 0.225]
-                    )
-                ]
-            )
-        
-        train_data = torchvision.datasets.CIFAR10(
-            root=data_dir, train=True,
-            download=True, transform=transform,
-        )
-    elif dataset == 'MNIST':
-        transform = Compose(
-                [
-                    Resize(256),
-                    CenterCrop(224),
-                    ToTensor(),
-                    Normalize(
-                        (0.1307,), (0.3081,)
-                    )
-                ]
-            )
-        
-        train_data = torchvision.datasets.MNIST(
-            root=data_dir, train=True,
-            download=True, transform=transform,
-        )
-
-    print("Done Loading Dataset.")
-    
-    train_sampler = RandomSampler(train_data)
-
-    train_loader = torch.utils.data.DataLoader(
-        train_data, batch_size=batch_size, sampler=train_sampler)
-
-    return train_loader
-
 def main():
-    """ print("Loading Dataset...")
-    cifar10 = torchvision.datasets.CIFAR10(
-        root='./data', train=True,
-        download=True, transform = Compose(
-            [
-                Resize(256),
-                CenterCrop(224),
-                ToTensor(),
-                Normalize(
-                    mean=[0.485, 0.456, 0.406],
-                    std=[0.229, 0.224, 0.225]
-                )
-            ]
-        )
-    )
-    print("Done Loading Dataset.") """
     dataset_name = 'MNIST'
+    
     device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
     print("Train on device:", device)
     
@@ -136,7 +77,7 @@ def main():
 
     #loader = torch.utils.data.DataLoader(cifar10, batch_size=batch_size)
 
-    train_loader = train_validation_data(data_dir='./data', batch_size=batch_size, dataset='MNIST', seed=1)
+    train_loader = dataset_loader(dataset_name, './data', batch_size)
     
     print("Starting Training...")
     DC_model.fit(train_loader)

--- a/deepcluster/train_deep_cluster.py
+++ b/deepcluster/train_deep_cluster.py
@@ -72,7 +72,7 @@ def main():
         cluster_assign_tf=ca_tf,
         epochs=3,
         dataset_name=dataset_name,
-        clustering_method='sklearn'
+        clustering_method='sklearn',
     )
 
     #loader = torch.utils.data.DataLoader(cifar10, batch_size=batch_size)

--- a/deepcluster/utils/benchmarking.py
+++ b/deepcluster/utils/benchmarking.py
@@ -1,0 +1,15 @@
+class Meter:
+    def __init__(self):
+        self.reset()
+
+    def reset(self):
+        self.val = 0
+        self.avg = 0
+        self.sum = 0
+        self.count = 0
+
+    def update(self, val, n=1):
+        self.val = val
+        self.sum += val * n
+        self.count += n
+        self.avg = self.sum / self.count

--- a/deepcluster/utils/datasets.py
+++ b/deepcluster/utils/datasets.py
@@ -1,0 +1,67 @@
+from torchvision import datasets
+from torchvision import transforms
+from torch.utils import data
+
+AVAILABLE_DATASETS = ['CIFAR10', 'MNIST', 'FashionMNIST', 'KMNIST']
+BASE_TRANSFORM = [
+    transforms.Resize(256), # Resize to the necessary size
+    transforms.CenterCrop(224),
+    transforms.ToTensor()
+]
+
+NORMALIZATION = {
+    'CIFAR10': transforms.Normalize(
+        mean=[0.485, 0.456, 0.406],
+        std=[0.229, 0.224, 0.225]
+    ),
+    'MNIST': transforms.Normalize(
+        mean=(0.1307,),
+        std=(0.3081,)
+    ),
+}
+
+def dataset_loader(dataset_name: str, data_dir: str, batch_size: int) -> data.DataLoader:
+    """Helper Function to simplify loading the training datasets.
+
+    Parameters
+    ----------
+    dataset_name: str,
+        Which dataset to load of the following options:
+        - CIFAR10
+        - MNIST
+        - FashionMNIST
+        - KMNIST
+        
+        data_dir: str,
+            The base folder where the dataset is stored physically.
+        
+        batch_size: int,
+            How many images per iterations are trained.
+
+    Returns
+    -------
+    data.DataLoader:
+        The expected dataset with the specific transformation
+    """
+    if dataset_name not in AVAILABLE_DATASETS:
+        raise ValueError(f'Dataset \'{dataset_name}\' currently not supported.')
+
+    tf = BASE_TRANSFORM
+    tf.append(NORMALIZATION[dataset_name])
+    tf = transforms.Compose(tf)
+    print('Loading dataset...')
+    loader = getattr(datasets, dataset_name)
+    dataset = loader(
+        root=data_dir, 
+        train=True, 
+        download=True, 
+        transform=tf
+    )
+    print('Done loading...')
+    
+    train_loader = data.DataLoader(
+        dataset=dataset, 
+        batch_size=batch_size
+    )
+    
+    return train_loader


### PR DESCRIPTION
This PR adds the following functionalities:

1. In-Algorithm Benchmarking
- added two additional variables in the DeepCluster init method (metrics and metrics_file)
  - metrics: If metrics shall be measured
  - metrics_file place to store or where a previously existing file is stored
- added parameters where the following information is stored:
  - epoch_time: time measurement for the overall epoch (only one, not all n epochs)
  - traing_time: time measurement for the training process of one epoch
  - feature_time: time measurement for the computation of the features of one epoch
  - pca_time: time measurement for the PCA reduction for one epoch
  - cluster_time: time measurement for the clustering of the reduced features
  - accuracy_overall_avg: Accuracy measurement and storage
  - loss_overall_avg: Loss measurement and storage
 - added a method to print the metrics, when activate, after each result print
 - added a method to create and append the metrics to a .csv
   - Creates a folder './metrics/'
   - Creates a sub-folder with the dataset name
   - creates a new file, when not existing, in the form of date and model (YYYY-MM-DD_modelname.csv)
   - Appends data for each epoch from the metrics
   - Header is as follows:
     - 'epoch', 'loss_avg', 'accuracy', 'nmi_true_ped', 'nmi_epochs', 'epoch_time', 'train_time', 'features_time', 'cluster_time', 'pca_time'
 
2. Torchvision dataset simplified
- Simplified the dataset retrieval from the torchvision.datasets structure
- Works for MNIST and CIFAR10, others are possible but needs normalization values
- Everything is now stored in the utils folder of the deepcluster folder in the file 'datasets.py'

Note to 1: When restarting an algorithm and only activating metrics but not giving a filename. In the case that a file already exists, the algorithm won't delete the file and instead just append and start from epoch at 0. The file either needs to be deleted manually or renamed to not corrupt the metrics output.
Feel free to do the necessary adjustments, as this is a simple solution. 
@egecimsir @FloKit @handler-bird 